### PR TITLE
EN-15946 Preserve Event content and root namespace declarations

### DIFF
--- a/mpd.go
+++ b/mpd.go
@@ -12,10 +12,18 @@ import (
 
 // MPD represents root XML element.
 type MPD struct {
-	XMLNS                      *string               `xml:"xmlns,attr"`
-	XMLNSXSI                   *string               `xml:"xmlns:xsi,attr"`
-	Ns2                        *string               `xml:"ns2,attr"`
-	Xsi                        *string               `xml:"xsi,attr"`
+	// Namespaces holds the namespace declarations found on the root element.
+	// encoding/xml cannot round-trip these through struct tags: it reports
+	// them as attributes in the "xmlns" namespace when decoding and mangles
+	// them into "_xmlns:prefix" when encoding, so UnmarshalXML/MarshalXML
+	// carry them instead.
+	//
+	// Losing them corrupts any content that uses a prefix. An scte35: SCTE-35
+	// payload kept verbatim in Event.InnerXML is the case that motivated this:
+	// without its declaration the prefix is unbound and the manifest is no
+	// longer namespace-well-formed.
+	Namespaces []xml.Attr `xml:"-"`
+
 	XsiSchemaLocation          *string               `xml:"xsi:schemaLocation,attr"`
 	SchemaLocation             *string               `xml:"schemaLocation,attr"`
 	Type                       *string               `xml:"type,attr"`
@@ -39,18 +47,64 @@ type MPD struct {
 	EssentialProperties        []*Descriptor         `xml:"EssentialProperty,omitempty"`
 	SupplementalProperties     []*Descriptor         `xml:"SupplementalProperty,omitempty"`
 	UtcTimings                 []*UtcTiming          `xml:"UTCTiming,omitempty"`
-	XmlnsCenc                  *string               `xml:"xmlns:cenc,attr"`
-	Cenc                       *string               `xml:"cenc,attr"`
-	Mspr                       *string               `xml:"mspr,attr"`
-	XmlnsMspr                  *string               `xml:"xmlns:mspr,attr"`
-	Mas                        *string               `xml:"mas,attr"`
-	XmlnsMas                   *string               `xml:"xmlns:mas,attr"`
 }
 
 // Do not try to use encoding.TextMarshaler and encoding.TextUnmarshaler:
 // https://github.com/golang/go/issues/6859#issuecomment-118890463
 
 // Encode generates MPD XML.
+// UnmarshalXML decodes the MPD and keeps the root namespace declarations,
+// which the struct tags cannot represent.
+func (m *MPD) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	// plain drops the methods on MPD so DecodeElement does not recurse.
+	type plain MPD
+
+	if err := d.DecodeElement((*plain)(m), &start); err != nil {
+		return err
+	}
+
+	m.Namespaces = namespaceDeclarations(start.Attr)
+
+	return nil
+}
+
+// MarshalXML encodes the MPD and restores the root namespace declarations.
+func (m *MPD) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	type plain MPD
+
+	start.Name = xml.Name{Local: "MPD"}
+	start.Attr = append(append([]xml.Attr(nil), start.Attr...), m.Namespaces...)
+
+	return e.EncodeElement((*plain)(m), start)
+}
+
+// namespaceDeclarations picks the xmlns declarations out of a start element's
+// attributes and rewrites them into a form the encoder emits verbatim: writing
+// the whole "xmlns:prefix" as the attribute's local name sidesteps encoding/xml
+// rewriting the prefix.
+func namespaceDeclarations(attrs []xml.Attr) []xml.Attr {
+	var declarations []xml.Attr
+
+	for _, attr := range attrs {
+		switch {
+		case attr.Name.Space == "xmlns":
+			// xmlns:prefix="uri"
+			declarations = append(declarations, xml.Attr{
+				Name:  xml.Name{Local: "xmlns:" + attr.Name.Local},
+				Value: attr.Value,
+			})
+		case attr.Name.Space == "" && attr.Name.Local == "xmlns":
+			// xmlns="uri"
+			declarations = append(declarations, xml.Attr{
+				Name:  xml.Name{Local: "xmlns"},
+				Value: attr.Value,
+			})
+		}
+	}
+
+	return declarations
+}
+
 func (m *MPD) Encode() ([]byte, error) {
 	x := new(bytes.Buffer)
 	e := xml.NewEncoder(x)

--- a/mpd.go
+++ b/mpd.go
@@ -53,10 +53,19 @@ type MPD struct {
 // https://github.com/golang/go/issues/6859#issuecomment-118890463
 
 // Encode generates MPD XML.
-// UnmarshalXML decodes the MPD and keeps the root namespace declarations,
-// which the struct tags cannot represent.
+// Namespace declarations have to be carried by hand. encoding/xml reports them
+// as attributes in the "xmlns" namespace when decoding and mangles them into
+// "_xmlns:prefix" when encoding, so struct tags cannot round-trip them.
+//
+// Every element between the root and Event content needs this, not just the
+// root: Event.InnerXML keeps prefixed children verbatim, so a declaration on
+// any ancestor that goes missing leaves those prefixes unbound and the
+// manifest no longer namespace-well-formed. Each element re-emits exactly the
+// declarations it carried, which preserves the original scoping.
+
+// UnmarshalXML decodes the MPD and keeps its namespace declarations.
 func (m *MPD) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
-	// plain drops the methods on MPD so DecodeElement does not recurse.
+	// plain drops the methods so DecodeElement does not recurse.
 	type plain MPD
 
 	if err := d.DecodeElement((*plain)(m), &start); err != nil {
@@ -68,14 +77,81 @@ func (m *MPD) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	return nil
 }
 
-// MarshalXML encodes the MPD and restores the root namespace declarations.
+// MarshalXML encodes the MPD and restores its namespace declarations.
 func (m *MPD) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	type plain MPD
 
-	start.Name = xml.Name{Local: "MPD"}
-	start.Attr = append(append([]xml.Attr(nil), start.Attr...), m.Namespaces...)
+	return e.EncodeElement((*plain)(m), withNamespaces(start, m.Namespaces))
+}
 
-	return e.EncodeElement((*plain)(m), start)
+// UnmarshalXML decodes the Period and keeps its namespace declarations.
+func (p *Period) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	type plain Period
+
+	if err := d.DecodeElement((*plain)(p), &start); err != nil {
+		return err
+	}
+
+	p.Namespaces = namespaceDeclarations(start.Attr)
+
+	return nil
+}
+
+// MarshalXML encodes the Period and restores its namespace declarations.
+func (p *Period) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	type plain Period
+
+	return e.EncodeElement((*plain)(p), withNamespaces(start, p.Namespaces))
+}
+
+// UnmarshalXML decodes the EventStream and keeps its namespace declarations.
+func (s *EventStream) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	type plain EventStream
+
+	if err := d.DecodeElement((*plain)(s), &start); err != nil {
+		return err
+	}
+
+	s.Namespaces = namespaceDeclarations(start.Attr)
+
+	return nil
+}
+
+// MarshalXML encodes the EventStream and restores its namespace declarations.
+func (s *EventStream) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	type plain EventStream
+
+	return e.EncodeElement((*plain)(s), withNamespaces(start, s.Namespaces))
+}
+
+// UnmarshalXML decodes the Event and keeps its namespace declarations, which
+// are often the ones its InnerXML payload depends on.
+func (v *Event) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	type plain Event
+
+	if err := d.DecodeElement((*plain)(v), &start); err != nil {
+		return err
+	}
+
+	v.Namespaces = namespaceDeclarations(start.Attr)
+
+	return nil
+}
+
+// MarshalXML encodes the Event and restores its namespace declarations.
+func (v *Event) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	type plain Event
+
+	return e.EncodeElement((*plain)(v), withNamespaces(start, v.Namespaces))
+}
+
+// withNamespaces adds the declarations to a start element. The element name is
+// left alone: EventStream, for one, is encoded as both EventStream and
+// InbandEventStream depending on the field it came from.
+func withNamespaces(start xml.StartElement, declarations []xml.Attr) xml.StartElement {
+	start.Attr = append(append([]xml.Attr(nil), start.Attr...), declarations...)
+
+	return start
 }
 
 // namespaceDeclarations picks the xmlns declarations out of a start element's
@@ -162,6 +238,11 @@ type SegmentList struct {
 }
 
 type Event struct {
+	// Namespaces holds the xmlns declarations carried by this element. A
+	// prefix used inside InnerXML may be declared here rather than higher up,
+	// and dropping the declaration would leave it unbound. See MPD.Namespaces.
+	Namespaces []xml.Attr `xml:"-"`
+
 	// InnerXML holds the element content verbatim. EventType allows arbitrary
 	// element content (xs:any), so this cannot be a chardata field: SCTE-35
 	// payloads such as scte35:SpliceInfoSection are child elements and a
@@ -174,6 +255,10 @@ type Event struct {
 }
 
 type EventStream struct {
+	// Namespaces holds the xmlns declarations carried by this element, which
+	// may be the ones an Event payload below it relies on. See MPD.Namespaces.
+	Namespaces []xml.Attr `xml:"-"`
+
 	Events      []*Event `xml:"Event,omitempty"`
 	Href        *string  `xml:"href,attr"`
 	Actuate     *string  `xml:"actuate,attr"`
@@ -190,6 +275,10 @@ type Subset struct {
 
 // Period represents XSD's PeriodType.
 type Period struct {
+	// Namespaces holds the xmlns declarations carried by this element, which
+	// may be the ones an Event payload below it relies on. See MPD.Namespaces.
+	Namespaces []xml.Attr `xml:"-"`
+
 	ID                 *string `xml:"id,attr"`
 	Start              *string `xml:"start,attr"`
 	Duration           *string `xml:"duration,attr"`

--- a/mpd.go
+++ b/mpd.go
@@ -108,7 +108,11 @@ type SegmentList struct {
 }
 
 type Event struct {
-	Value            string  `xml:",chardata"`
+	// InnerXML holds the element content verbatim. EventType allows arbitrary
+	// element content (xs:any), so this cannot be a chardata field: SCTE-35
+	// payloads such as scte35:SpliceInfoSection are child elements and a
+	// chardata field would silently drop them on decode.
+	InnerXML         string  `xml:",innerxml"`
 	PresentationTime *uint64 `xml:"presentationTime,attr"`
 	Duration         *uint64 `xml:"duration,attr"`
 	ID               *uint64 `xml:"id,attr"`

--- a/mpd_test.go
+++ b/mpd_test.go
@@ -106,18 +106,41 @@ func Test_EventInnerXMLRoundTrip(t *testing.T) {
 			if err := m.Decode(in); err != nil {
 				t.Fatalf("Decode: %v", err)
 			}
-
-			events := m.Period[0].EventStreams[0].Events
-			if len(events) != 1 {
-				t.Fatalf("expected 1 Event, got %d", len(events))
-			}
-			assert.Equal(t, tt.content, events[0].InnerXML, "Event content lost on decode")
+			assert.Equal(t, tt.content, soleEventContent(t, m), "Event content lost on decode")
 
 			obtained, err := m.Encode()
 			if err != nil {
 				t.Fatalf("Encode: %v", err)
 			}
-			assert.Contains(t, string(obtained), tt.content, "Event content lost on encode")
+
+			// Re-decode rather than substring match: Contains is a no-op for
+			// the empty case, and would not notice the payload being escaped
+			// into chardata on the way out.
+			reDecoded := new(MPD)
+			if err := reDecoded.Decode(obtained); err != nil {
+				t.Fatalf("Decode of encoded output: %v\n%s", err, obtained)
+			}
+			assert.Equal(t, tt.content, soleEventContent(t, reDecoded), "Event content lost on encode:\n%s", obtained)
 		})
 	}
+}
+
+// soleEventContent returns the InnerXML of the single Event the test manifests
+// carry, failing rather than panicking when the shape is not what we expect.
+func soleEventContent(t *testing.T, m *MPD) string {
+	t.Helper()
+
+	if len(m.Period) != 1 {
+		t.Fatalf("expected 1 Period, got %d", len(m.Period))
+	}
+	if len(m.Period[0].EventStreams) != 1 {
+		t.Fatalf("expected 1 EventStream, got %d", len(m.Period[0].EventStreams))
+	}
+
+	events := m.Period[0].EventStreams[0].Events
+	if len(events) != 1 {
+		t.Fatalf("expected 1 Event, got %d", len(events))
+	}
+
+	return events[0].InnerXML
 }

--- a/mpd_test.go
+++ b/mpd_test.go
@@ -270,13 +270,7 @@ func assertPrefixesBound(t *testing.T, document []byte) {
 		switch element := token.(type) {
 		case xml.StartElement:
 			// Declarations take effect on the element that carries them.
-			frame := map[string]bool{}
-			for _, attr := range element.Attr {
-				if attr.Name.Space == "xmlns" || attr.Name.Local == "xmlns" {
-					frame[attr.Value] = true
-				}
-			}
-			scopes = append(scopes, frame)
+			scopes = append(scopes, declaredNamespaces(element.Attr))
 
 			// An unbound prefix is reported verbatim as the namespace, so
 			// anything not matching a declaration in scope means the
@@ -289,6 +283,19 @@ func assertPrefixesBound(t *testing.T, document []byte) {
 			scopes = scopes[:len(scopes)-1]
 		}
 	}
+}
+
+// declaredNamespaces returns the namespace URIs an element declares.
+func declaredNamespaces(attrs []xml.Attr) map[string]bool {
+	declared := map[string]bool{}
+
+	for _, attr := range attrs {
+		if attr.Name.Space == "xmlns" || attr.Name.Local == "xmlns" {
+			declared[attr.Value] = true
+		}
+	}
+
+	return declared
 }
 
 func inScope(scopes []map[string]bool, namespace string) bool {

--- a/mpd_test.go
+++ b/mpd_test.go
@@ -1,8 +1,11 @@
 package mpd
 
 import (
+	"bytes"
+	"encoding/xml"
 	"fmt"
 	"github.com/stretchr/testify/assert"
+	"io"
 	"os"
 	"strings"
 	"testing"
@@ -143,4 +146,142 @@ func soleEventContent(t *testing.T, m *MPD) string {
 	}
 
 	return events[0].InnerXML
+}
+
+// Test_RootNamespaceDeclarationsPreserved guards the root xmlns declarations.
+// encoding/xml drops or mangles them by default, which leaves any prefix used
+// further down the manifest unbound.
+func Test_RootNamespaceDeclarationsPreserved(t *testing.T) {
+	tests := []struct {
+		name         string
+		rootAttrs    string
+		wantDeclared []string
+	}{
+		{
+			name:         "default namespace only",
+			rootAttrs:    `xmlns="urn:mpeg:dash:schema:mpd:2011"`,
+			wantDeclared: []string{`xmlns="urn:mpeg:dash:schema:mpd:2011"`},
+		},
+		{
+			name:      "default and scte35",
+			rootAttrs: `xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:scte35="https://www.scte.org/schemas/35"`,
+			wantDeclared: []string{
+				`xmlns="urn:mpeg:dash:schema:mpd:2011"`,
+				`xmlns:scte35="https://www.scte.org/schemas/35"`,
+			},
+		},
+		{
+			name:      "drm prefixes",
+			rootAttrs: `xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:cenc="urn:mpeg:cenc:2013" xmlns:mspr="urn:microsoft:playready" xmlns:mas="urn:marlin:mas:1-0:services:schemas:mpd"`,
+			wantDeclared: []string{
+				`xmlns:cenc="urn:mpeg:cenc:2013"`,
+				`xmlns:mspr="urn:microsoft:playready"`,
+				`xmlns:mas="urn:marlin:mas:1-0:services:schemas:mpd"`,
+			},
+		},
+		{
+			name:      "xlink and xsi",
+			rootAttrs: `xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:ns2="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"`,
+			wantDeclared: []string{
+				`xmlns:ns2="http://www.w3.org/1999/xlink"`,
+				`xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"`,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			in := []byte(`<?xml version="1.0" encoding="UTF-8"?>
+<MPD ` + tt.rootAttrs + ` profiles="urn:mpeg:dash:profile:isoff-live:2011" type="dynamic">
+  <Period id="p0"/>
+</MPD>`)
+
+			m := new(MPD)
+			if err := m.Decode(in); err != nil {
+				t.Fatalf("Decode: %v", err)
+			}
+
+			obtained, err := m.Encode()
+			if err != nil {
+				t.Fatalf("Encode: %v", err)
+			}
+
+			for _, declaration := range tt.wantDeclared {
+				assert.Equal(t, 1, strings.Count(string(obtained), declaration),
+					"expected %s exactly once in:\n%s", declaration, obtained)
+			}
+		})
+	}
+}
+
+// Test_EncodedPrefixesStayBound re-parses everything in testdata after a round
+// trip and fails on any element whose prefix has no declaration in scope.
+// encoding/xml does not reject unbound prefixes, it reports the raw prefix as
+// the namespace, so this walks the tokens rather than relying on a decode error.
+func Test_EncodedPrefixesStayBound(t *testing.T) {
+	files, err := os.ReadDir("testdata")
+	if err != nil {
+		t.Fatalf("Failed to read testdata directory: %v", err)
+	}
+
+	for _, file := range files {
+		if file.IsDir() || !strings.HasSuffix(file.Name(), ".mpd") {
+			continue
+		}
+
+		t.Run(file.Name(), func(t *testing.T) {
+			source, err := os.ReadFile("testdata/" + file.Name())
+			if err != nil {
+				t.Fatalf("Failed to read file %s: %v", file.Name(), err)
+			}
+
+			m := new(MPD)
+			if err := m.Decode(source); err != nil {
+				t.Fatalf("Decode: %v", err)
+			}
+
+			obtained, err := m.Encode()
+			if err != nil {
+				t.Fatalf("Encode: %v", err)
+			}
+
+			assertPrefixesBound(t, obtained)
+		})
+	}
+}
+
+func assertPrefixesBound(t *testing.T, document []byte) {
+	t.Helper()
+
+	declared := map[string]bool{"": true}
+	decoder := xml.NewDecoder(bytes.NewReader(document))
+
+	for {
+		token, err := decoder.Token()
+		if err == io.EOF {
+			return
+		}
+		if err != nil {
+			t.Fatalf("Failed to re-parse encoded output: %v\n%s", err, document)
+		}
+
+		element, ok := token.(xml.StartElement)
+		if !ok {
+			continue
+		}
+
+		// Declarations take effect on the element that carries them.
+		for _, attr := range element.Attr {
+			if attr.Name.Space == "xmlns" || attr.Name.Local == "xmlns" {
+				declared[attr.Value] = true
+			}
+		}
+
+		// An unbound prefix is reported verbatim as the namespace, so anything
+		// not matching a declared URI means the declaration went missing.
+		if !declared[element.Name.Space] {
+			t.Errorf("element %q uses unbound namespace prefix %q\n%s",
+				element.Name.Local, element.Name.Space, document)
+		}
+	}
 }

--- a/mpd_test.go
+++ b/mpd_test.go
@@ -4,11 +4,12 @@ import (
 	"bytes"
 	"encoding/xml"
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"io"
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/pschlump/xml-diff/xmllib"
 	"github.com/sergi/go-diff/diffmatchpatch"

--- a/mpd_test.go
+++ b/mpd_test.go
@@ -253,7 +253,9 @@ func Test_EncodedPrefixesStayBound(t *testing.T) {
 func assertPrefixesBound(t *testing.T, document []byte) {
 	t.Helper()
 
-	declared := map[string]bool{"": true}
+	// One frame per open element, so a declaration goes out of scope with the
+	// element that carried it rather than leaking into later siblings.
+	scopes := []map[string]bool{{"": true}}
 	decoder := xml.NewDecoder(bytes.NewReader(document))
 
 	for {
@@ -265,23 +267,86 @@ func assertPrefixesBound(t *testing.T, document []byte) {
 			t.Fatalf("Failed to re-parse encoded output: %v\n%s", err, document)
 		}
 
-		element, ok := token.(xml.StartElement)
-		if !ok {
-			continue
-		}
-
-		// Declarations take effect on the element that carries them.
-		for _, attr := range element.Attr {
-			if attr.Name.Space == "xmlns" || attr.Name.Local == "xmlns" {
-				declared[attr.Value] = true
+		switch element := token.(type) {
+		case xml.StartElement:
+			// Declarations take effect on the element that carries them.
+			frame := map[string]bool{}
+			for _, attr := range element.Attr {
+				if attr.Name.Space == "xmlns" || attr.Name.Local == "xmlns" {
+					frame[attr.Value] = true
+				}
 			}
-		}
+			scopes = append(scopes, frame)
 
-		// An unbound prefix is reported verbatim as the namespace, so anything
-		// not matching a declared URI means the declaration went missing.
-		if !declared[element.Name.Space] {
-			t.Errorf("element %q uses unbound namespace prefix %q\n%s",
-				element.Name.Local, element.Name.Space, document)
+			// An unbound prefix is reported verbatim as the namespace, so
+			// anything not matching a declaration in scope means the
+			// declaration went missing.
+			if !inScope(scopes, element.Name.Space) {
+				t.Errorf("element %q uses unbound namespace prefix %q\n%s",
+					element.Name.Local, element.Name.Space, document)
+			}
+		case xml.EndElement:
+			scopes = scopes[:len(scopes)-1]
 		}
+	}
+}
+
+func inScope(scopes []map[string]bool, namespace string) bool {
+	for i := len(scopes) - 1; i >= 0; i-- {
+		if scopes[i][namespace] {
+			return true
+		}
+	}
+
+	return false
+}
+
+// Test_AncestorNamespaceDeclarationsPreserved covers declarations placed
+// somewhere between the root and the Event payload. Event.InnerXML keeps
+// prefixed children verbatim, so a declaration dropped from any ancestor
+// leaves those prefixes unbound.
+func Test_AncestorNamespaceDeclarationsPreserved(t *testing.T) {
+	const declaration = ` xmlns:scte35="https://www.scte.org/schemas/35"`
+	const payload = `<scte35:SpliceInfoSection tier="4095"><scte35:SpliceInsert spliceEventId="558"/></scte35:SpliceInfoSection>`
+
+	tests := []struct {
+		name        string
+		mpd         string
+		period      string
+		eventStream string
+		event       string
+	}{
+		{name: "declared on MPD", mpd: declaration},
+		{name: "declared on Period", period: declaration},
+		{name: "declared on EventStream", eventStream: declaration},
+		{name: "declared on Event", event: declaration},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			in := []byte(`<?xml version="1.0" encoding="UTF-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" profiles="urn:mpeg:dash:profile:isoff-live:2011" type="dynamic"` + tt.mpd + `>
+  <Period id="p0"` + tt.period + `>
+    <EventStream schemeIdUri="urn:scte:scte35:2013:xml" timescale="90000"` + tt.eventStream + `>
+      <Event presentationTime="1" id="1"` + tt.event + `>` + payload + `</Event>
+    </EventStream>
+  </Period>
+</MPD>`)
+
+			m := new(MPD)
+			if err := m.Decode(in); err != nil {
+				t.Fatalf("Decode: %v", err)
+			}
+
+			obtained, err := m.Encode()
+			if err != nil {
+				t.Fatalf("Encode: %v", err)
+			}
+
+			assert.Contains(t, string(obtained), payload, "SCTE-35 payload lost")
+			assert.Equal(t, 1, strings.Count(string(obtained), `xmlns:scte35="https://www.scte.org/schemas/35"`),
+				"expected the declaration exactly once in:\n%s", obtained)
+			assertPrefixesBound(t, obtained)
+		})
 	}
 }

--- a/mpd_test.go
+++ b/mpd_test.go
@@ -250,62 +250,124 @@ func Test_EncodedPrefixesStayBound(t *testing.T) {
 	}
 }
 
+// assertPrefixesBound fails when the document uses a namespace prefix with no
+// declaration in scope, on an element or on an attribute.
+//
+// This walks RawToken rather than Token deliberately. Token resolves a bound
+// prefix to its URI but leaves an unbound one verbatim, so a check keyed on the
+// resolved value cannot tell the two apart: in <root xmlns:a="b"><b:child/></root>
+// the declared URI and the undeclared prefix are both "b" and the document
+// looks fine. RawToken reports prefixes as written, so declarations can be
+// tracked by prefix name instead.
 func assertPrefixesBound(t *testing.T, document []byte) {
 	t.Helper()
 
+	unbound, err := unboundPrefixes(document)
+	if err != nil {
+		t.Fatalf("Failed to re-parse encoded output: %v\n%s", err, document)
+	}
+
+	for _, problem := range unbound {
+		t.Errorf("%s\n%s", problem, document)
+	}
+}
+
+// unboundPrefixes reports every namespace prefix used without a declaration in
+// scope, on an element or on an attribute.
+//
+// This walks RawToken rather than Token deliberately. Token resolves a bound
+// prefix to its URI but leaves an unbound one verbatim, so a check keyed on the
+// resolved value cannot tell the two apart: in <root xmlns:a="b"><b:child/></root>
+// the declared URI and the undeclared prefix are both "b" and the document
+// looks fine. RawToken reports prefixes as written, so declarations can be
+// tracked by prefix name instead.
+func unboundPrefixes(document []byte) ([]string, error) {
+	var unbound []string
+
 	// One frame per open element, so a declaration goes out of scope with the
-	// element that carried it rather than leaking into later siblings.
-	scopes := []map[string]bool{{"": true}}
+	// element that carried it rather than leaking into later siblings. The
+	// empty prefix needs no declaration and xml is bound implicitly.
+	scopes := []map[string]bool{{"": true, "xml": true}}
 	decoder := xml.NewDecoder(bytes.NewReader(document))
 
 	for {
-		token, err := decoder.Token()
+		token, err := decoder.RawToken()
 		if err == io.EOF {
-			return
+			return unbound, nil
 		}
 		if err != nil {
-			t.Fatalf("Failed to re-parse encoded output: %v\n%s", err, document)
+			return nil, err
 		}
 
 		switch element := token.(type) {
 		case xml.StartElement:
 			// Declarations take effect on the element that carries them.
-			scopes = append(scopes, declaredNamespaces(element.Attr))
-
-			// An unbound prefix is reported verbatim as the namespace, so
-			// anything not matching a declaration in scope means the
-			// declaration went missing.
-			if !inScope(scopes, element.Name.Space) {
-				t.Errorf("element %q uses unbound namespace prefix %q\n%s",
-					element.Name.Local, element.Name.Space, document)
-			}
+			scopes = append(scopes, declaredPrefixes(element.Attr))
+			unbound = append(unbound, elementUnboundPrefixes(scopes, element)...)
 		case xml.EndElement:
-			scopes = scopes[:len(scopes)-1]
+			scopes = popScope(scopes)
 		}
 	}
 }
 
-// declaredNamespaces returns the namespace URIs an element declares.
-func declaredNamespaces(attrs []xml.Attr) map[string]bool {
+func elementUnboundPrefixes(scopes []map[string]bool, element xml.StartElement) []string {
+	var unbound []string
+
+	if !prefixInScope(scopes, element.Name.Space) {
+		unbound = append(unbound, fmt.Sprintf("element %q uses unbound namespace prefix %q",
+			element.Name.Local, element.Name.Space))
+	}
+
+	for _, attr := range element.Attr {
+		if isNamespaceDeclaration(attr) {
+			continue
+		}
+
+		if !prefixInScope(scopes, attr.Name.Space) {
+			unbound = append(unbound, fmt.Sprintf("attribute %q on element %q uses unbound namespace prefix %q",
+				attr.Name.Local, element.Name.Local, attr.Name.Space))
+		}
+	}
+
+	return unbound
+}
+
+// declaredPrefixes returns the prefixes an element declares. RawToken reports
+// xmlns:prefix="uri" as an attribute named prefix in the xmlns namespace.
+func declaredPrefixes(attrs []xml.Attr) map[string]bool {
 	declared := map[string]bool{}
 
 	for _, attr := range attrs {
-		if attr.Name.Space == "xmlns" || attr.Name.Local == "xmlns" {
-			declared[attr.Value] = true
+		if attr.Name.Space == "xmlns" {
+			declared[attr.Name.Local] = true
 		}
 	}
 
 	return declared
 }
 
-func inScope(scopes []map[string]bool, namespace string) bool {
+func isNamespaceDeclaration(attr xml.Attr) bool {
+	return attr.Name.Space == "xmlns" || (attr.Name.Space == "" && attr.Name.Local == "xmlns")
+}
+
+func prefixInScope(scopes []map[string]bool, prefix string) bool {
 	for i := len(scopes) - 1; i >= 0; i-- {
-		if scopes[i][namespace] {
+		if scopes[i][prefix] {
 			return true
 		}
 	}
 
 	return false
+}
+
+// popScope keeps the root frame, since RawToken does not check that start and
+// end elements match.
+func popScope(scopes []map[string]bool) []map[string]bool {
+	if len(scopes) == 1 {
+		return scopes
+	}
+
+	return scopes[:len(scopes)-1]
 }
 
 // Test_AncestorNamespaceDeclarationsPreserved covers declarations placed
@@ -354,6 +416,68 @@ func Test_AncestorNamespaceDeclarationsPreserved(t *testing.T) {
 			assert.Equal(t, 1, strings.Count(string(obtained), `xmlns:scte35="https://www.scte.org/schemas/35"`),
 				"expected the declaration exactly once in:\n%s", obtained)
 			assertPrefixesBound(t, obtained)
+		})
+	}
+}
+
+// Test_UnboundPrefixes covers the guard the namespace tests lean on. It has to
+// agree with a namespace-aware parser, including on documents where the
+// resolved-URI shortcut would be fooled.
+func Test_UnboundPrefixes(t *testing.T) {
+	tests := []struct {
+		name     string
+		document string
+		want     int
+	}{
+		{
+			name:     "no prefixes at all",
+			document: `<MPD xmlns="urn:mpeg:dash:schema:mpd:2011"><Period id="p0"/></MPD>`,
+		},
+		{
+			name:     "declared and used",
+			document: `<MPD xmlns="urn:d" xmlns:scte35="urn:s"><Period scte35:x="1"><scte35:Signal/></Period></MPD>`,
+		},
+		{
+			name:     "xml prefix needs no declaration",
+			document: `<MPD xmlns="urn:d"><Period xml:lang="en"/></MPD>`,
+		},
+		{
+			name:     "unbound element prefix",
+			document: `<MPD xmlns="urn:d"><scte35:Signal/></MPD>`,
+			want:     1,
+		},
+		{
+			name:     "unbound attribute prefix",
+			document: `<MPD xmlns="urn:d"><Period xlink:href="x"/></MPD>`,
+			want:     1,
+		},
+		{
+			name: "prefix matching a declared uri",
+			// Token would resolve the declaration to "b" and report the
+			// undeclared prefix as "b" too, so the two become
+			// indistinguishable. RawToken keeps them apart.
+			document: `<MPD xmlns:a="b"><b:child/></MPD>`,
+			want:     1,
+		},
+		{
+			name:     "declaration does not leak to a sibling",
+			document: `<MPD xmlns="urn:d"><Period xmlns:a="urn:a"><a:X/></Period><Period><a:Y/></Period></MPD>`,
+			want:     1,
+		},
+		{
+			name:     "declaration reaches a descendant",
+			document: `<MPD xmlns="urn:d" xmlns:a="urn:a"><Period><EventStream><a:X/></EventStream></Period></MPD>`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			unbound, err := unboundPrefixes([]byte(tt.document))
+			if err != nil {
+				t.Fatalf("unboundPrefixes: %v", err)
+			}
+
+			assert.Len(t, unbound, tt.want, "got %v", unbound)
 		})
 	}
 }

--- a/mpd_test.go
+++ b/mpd_test.go
@@ -60,3 +60,64 @@ func Test_UnmarshalMarshalAllFiles(t *testing.T) {
 		}
 	}
 }
+
+// Test_EventInnerXMLRoundTrip guards the Event element content against being
+// dropped. EventType permits arbitrary element content, so anything other than
+// a verbatim round trip silently corrupts SCTE-35 signalling.
+func Test_EventInnerXMLRoundTrip(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+	}{
+		{
+			name:    "scte35 xml payload",
+			content: `<scte35:SpliceInfoSection xmlns:scte35="https://www.scte.org/schemas/35" tier="4095"><scte35:SpliceInsert spliceEventId="558" outOfNetworkIndicator="true"><scte35:Program><scte35:SpliceTime ptsTime="5190214887"/></scte35:Program></scte35:SpliceInsert></scte35:SpliceInfoSection>`,
+		},
+		{
+			name:    "scte35 binary payload",
+			content: `<Signal xmlns="urn:scte:scte35:2013:xml"><Binary>/DAlAAAAAAAAAP/wFAUAAAABf+/+AA==</Binary></Signal>`,
+		},
+		{
+			name:    "base64 chardata",
+			content: `SGVsbG8gJiB3b3JsZA==`,
+		},
+		{
+			name:    "escaped chardata",
+			content: `text with &amp; escaped &lt;chars&gt;`,
+		},
+		{
+			name:    "empty",
+			content: ``,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			in := []byte(`<?xml version="1.0" encoding="UTF-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" profiles="urn:mpeg:dash:profile:isoff-live:2011" type="dynamic">
+  <Period id="p0">
+    <EventStream schemeIdUri="urn:scte:scte35:2013:xml" timescale="90000">
+      <Event presentationTime="40814816400" duration="10800000" id="103571352">` + tt.content + `</Event>
+    </EventStream>
+  </Period>
+</MPD>`)
+
+			m := new(MPD)
+			if err := m.Decode(in); err != nil {
+				t.Fatalf("Decode: %v", err)
+			}
+
+			events := m.Period[0].EventStreams[0].Events
+			if len(events) != 1 {
+				t.Fatalf("expected 1 Event, got %d", len(events))
+			}
+			assert.Equal(t, tt.content, events[0].InnerXML, "Event content lost on decode")
+
+			obtained, err := m.Encode()
+			if err != nil {
+				t.Fatalf("Encode: %v", err)
+			}
+			assert.Contains(t, string(obtained), tt.content, "Event content lost on encode")
+		})
+	}
+}

--- a/testdata/live_with_root_declared_scte35_namespace.mpd
+++ b/testdata/live_with_root_declared_scte35_namespace.mpd
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:scte35="https://www.scte.org/schemas/35" id="b1c0f6a2-3d18-4c77-9f21-6de0b4c9a7e5" profiles="urn:mpeg:dash:profile:isoff-live:2011" type="dynamic" availabilityStartTime="2026-08-26T11:04:07.673Z" publishTime="2026-08-31T17:04:52.108Z" minimumUpdatePeriod="P0Y0M0DT0H0M3.840S" minBufferTime="P0Y0M0DT0H0M2.000S" timeShiftBufferDepth="P0Y0M0DT0H3M0.000S">
+  <Period id="8f2b41d7-5a90-4e63-b0cc-721ae5f38d94" start="P0Y0M0DT0H0M0.000S">
+    <EventStream schemeIdUri="urn:scte:scte35:2013:xml" timescale="90000">
+      <Event presentationTime="40814816400" duration="10800000" id="103571352">
+        <scte35:SpliceInfoSection sapType="3" protocolVersion="0" ptsAdjustment="1264863145" tier="4095">
+          <scte35:SpliceInsert spliceEventId="558" spliceEventCancelIndicator="false" outOfNetworkIndicator="true" spliceImmediateFlag="false" uniqueProgramId="1" availNum="46" availsExpected="46">
+            <scte35:Program>
+              <scte35:SpliceTime ptsTime="5190214887"/>
+            </scte35:Program>
+            <scte35:BreakDuration autoReturn="true" duration="10800000"/>
+          </scte35:SpliceInsert>
+        </scte35:SpliceInfoSection>
+      </Event>
+    </EventStream>
+    <AdaptationSet contentType="video" mimeType="video/mp4" segmentAlignment="true" par="16:9" maxWidth="1920" maxHeight="1080" startWithSAP="1">
+      <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main"/>
+      <Representation id="7c3e9a15-4b82-4d06-a5f9-2e8b17c04d3a" bandwidth="2400000" width="1920" height="1080" codecs="avc1.640028" sar="1:1" frameRate="25">
+        <SegmentTemplate media="video/1080p2400kbps/segment_$Number$_seg.m4s" startNumber="119199" timescale="25000" initialization="video/1080p2400kbps/init_init.m4s">
+          <SegmentTimeline>
+            <S t="11336832000" d="96000" r="5"/>
+          </SegmentTimeline>
+        </SegmentTemplate>
+      </Representation>
+    </AdaptationSet>
+  </Period>
+</MPD>

--- a/testdata/live_with_scte35_event_stream.mpd
+++ b/testdata/live_with_scte35_event_stream.mpd
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" id="ffeaf845-49df-4291-b265-a3300747365a" profiles="urn:hbbtv:dash:profile:isoff-live:2012,urn:mpeg:dash:profile:isoff-live:2011" type="dynamic" availabilityStartTime="2026-08-26T11:04:07.673Z" publishTime="2026-08-31T17:04:52.108Z" minimumUpdatePeriod="P0Y0M0DT0H0M3.840S" minBufferTime="P0Y0M0DT0H0M2.000S" timeShiftBufferDepth="P0Y0M0DT0H3M0.000S">
+  <Period id="39074896-992e-4839-918d-0524a7b9ef2e" start="P0Y0M0DT0H0M0.000S">
+    <EventStream schemeIdUri="urn:scte:scte35:2013:xml" timescale="90000">
+      <Event presentationTime="40814816400" duration="10800000" id="103571352">
+        <scte35:SpliceInfoSection xmlns:scte35="https://www.scte.org/schemas/35" sapType="3" protocolVersion="0" ptsAdjustment="1264863145" tier="4095">
+          <scte35:SpliceInsert spliceEventId="558" spliceEventCancelIndicator="false" outOfNetworkIndicator="true" spliceImmediateFlag="false" uniqueProgramId="1" availNum="46" availsExpected="46">
+            <scte35:Program>
+              <scte35:SpliceTime ptsTime="5190214887"/>
+            </scte35:Program>
+            <scte35:BreakDuration autoReturn="true" duration="10800000"/>
+          </scte35:SpliceInsert>
+        </scte35:SpliceInfoSection>
+      </Event>
+    </EventStream>
+    <AdaptationSet contentType="video" mimeType="video/mp4" segmentAlignment="true" par="16:9" maxWidth="1920" maxHeight="1080" startWithSAP="1">
+      <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main"/>
+      <Representation id="16d48268-d9ad-49b7-8373-40067cfd879e" bandwidth="2400000" width="1920" height="1080" codecs="avc1.640028" sar="1:1" frameRate="25">
+        <SegmentTemplate media="video/1080p2400kbps/segment_$Number$_seg.m4s" startNumber="119199" timescale="25000" initialization="video/1080p2400kbps/init_init.m4s">
+          <SegmentTimeline>
+            <S t="11336832000" d="96000" r="5"/>
+          </SegmentTimeline>
+        </SegmentTemplate>
+      </Representation>
+    </AdaptationSet>
+    <AdaptationSet contentType="audio" mimeType="audio/mp4" segmentAlignment="true" lang="ar" startWithSAP="1">
+      <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
+      <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main"/>
+      <Representation id="79e0937f-cf64-45af-8acf-f53b0c21bdd1" bandwidth="192000" codecs="mp4a.40.2" audioSamplingRate="48000">
+        <SegmentTemplate media="audio1/192kbps/segment_$Number$_seg.m4s" startNumber="119627" timescale="48000" initialization="audio1/192kbps/init_init.m4s">
+          <SegmentTimeline>
+            <S t="21766901760" d="184320" r="4"/>
+          </SegmentTimeline>
+        </SegmentTemplate>
+      </Representation>
+    </AdaptationSet>
+  </Period>
+</MPD>


### PR DESCRIPTION
Fixes the library side of [EN-15946](https://bitmovin.atlassian.net/browse/EN-15946): the manifest filtering service strips the SCTE-35 payload out of DASH `<Event>` elements for MBC live streams.

Two related bugs. The first is the reported one; the second was found while fixing it and had to be fixed in the same PR, because fixing only the first turns a lossy round trip into a malformed one.

## 1. Event content was dropped

`Event` declared its content as `xml:",chardata"`, which captures text nodes only. DASH's `EventType` permits arbitrary element content (`xs:any`), and an XML-form SCTE-35 payload lives in child elements. So `encoding/xml` silently discarded the whole `<scte35:SpliceInfoSection>` subtree on decode, and `Encode()` wrote back only the indentation whitespace it had captured, escaped as `&#xA;`. Attributes survived, which is why the `<Event>` shell looks intact.

```xml
<!-- in -->
<Event presentationTime="40814816400" id="103571352">
  <scte35:SpliceInfoSection xmlns:scte35="https://www.scte.org/schemas/35" tier="4095">
    <scte35:SpliceInsert spliceEventId="558" outOfNetworkIndicator="true">...</scte35:SpliceInsert>
  </scte35:SpliceInfoSection>
</Event>

<!-- out -->
<Event presentationTime="40814816400" id="103571352">&#xA;    &#xA;  </Event>
```

Fixed by switching the field to `xml:",innerxml"`. Verified against every content shape an `Event` can carry: nested SCTE-35 XML, `<Signal><Binary>` (`2014:xml+bin`), base64 chardata, pre-escaped text (preserved, not double-escaped), and empty. The only behaviour change is cosmetic: a self-closing `<Event/>` re-encodes as `<Event></Event>`.

`Event` is the only struct where `,chardata` was wrong. `BaseURL`, `Label`, `Pssh`, `Pro`, `MarlinContentId` and `UrlType` are text-only per spec and are untouched.

## 2. Root namespace declarations were destroyed

Round-tripping any MPD wrecked the `xmlns` declarations on the root element. Two causes, both from struct tags:

- Fields like `xml:"cenc,attr"` matched the declaration by local name on decode, then wrote it back as `cenc="urn:mpeg:cenc:2013"` — dropping the `xmlns:` and turning a declaration into a stray attribute.
- Their `xml:"xmlns:cenc,attr"` counterparts never matched anything on decode, because `encoding/xml` does not treat the colon as a separator when comparing tags.

So every declaration was either mangled or dropped. **On its own that was merely lossy** — prefixed children were re-encoded without their prefix, so the output stayed well-formed. Fix 1 changes that: preserving `InnerXML` verbatim means a manifest that declares `xmlns:scte35` anywhere on the chain down to the payload re-encodes with `scte35:` elements and no declaration in scope.

```
$ xmllint --noout out.mpd
namespace error : Namespace prefix scte35 on SpliceInfoSection is not defined
```

That is worse than the payload loss it replaces, so it is fixed here rather than deferred.

`UnmarshalXML` now takes the declarations off the start element and `MarshalXML` writes them back, for `MPD`, `Period`, `EventStream` and `Event` — the full ancestor chain of the only verbatim-preserved content the library has. Each element re-emits exactly what it carried, so the original scoping is preserved rather than everything being hoisted to the root. The trick that makes them survive is writing the whole `xmlns:prefix` as the attribute's *local* name — given a `Name.Space` of `"xmlns"`, `encoding/xml` emits `_xmlns:prefix`.

This replaces the per-prefix fields with a single `Namespaces []xml.Attr`, so declarations no longer have to be anticipated one prefix at a time. The DRM fixtures show declarations that were already broken before this PR:

```diff
-<MPD xmlns="..." cenc="urn:mpeg:cenc:2013" mas="urn:marlin:...">
+<MPD xmlns="..." xmlns:cenc="urn:mpeg:cenc:2013" xmlns:mas="urn:marlin:...">
```

## Tests

| Test | Covers |
| --- | --- |
| `testdata/live_with_scte35_event_stream.mpd` | inline-declared SCTE-35, via the existing round-trip diff |
| `testdata/live_with_root_declared_scte35_namespace.mpd` | root-declared SCTE-35, same |
| `Test_EventInnerXMLRoundTrip` | the five `Event` content shapes, decode and encode |
| `Test_RootNamespaceDeclarationsPreserved` | default, scte35, DRM and xlink/xsi declaration shapes |
| `Test_AncestorNamespaceDeclarationsPreserved` | a declaration on each of `MPD`, `Period`, `EventStream`, `Event` |
| `Test_EncodedPrefixesStayBound` | re-parses every encoded testdata file, fails on any prefix without a declaration in scope |

`Test_EncodedPrefixesStayBound` walks tokens rather than relying on a decode error, because `encoding/xml` does **not** reject unbound prefixes — it reports the raw prefix as the namespace. That leniency is why the problem was easy to miss.

Every test above fails without its corresponding fix. Full suite green, `gofmt`/`go vet` clean, and all 20 encoded testdata files parse cleanly under namespace-aware expat.

> A note on how that last claim is checked, since I got it wrong at first: **`xmllint --noout` exits 0 on namespace errors**, printing them to stderr only. Any sweep keyed on its exit status silently passes. The validation here uses expat with `feature_namespaces` enabled, which does fail, and `Test_EncodedPrefixesStayBound` is the in-repo equivalent.

## For reviewers

**Removed exported fields.** `Event.Value` becomes `Event.InnerXML`; `XMLNS`, `XMLNSXSI`, `Ns2`, `Xsi`, `Cenc`, `Mspr`, `Mas` and the `Xmlns*` variants are replaced by `Namespaces`. None had callers in manifest-filtering-service, and none of the namespace ones worked as intended. If another consumer depends on them, say so and I will add compatibility shims.

**Still not round-tripped: prefixed non-xmlns attributes.** `xsi:schemaLocation` decodes into `SchemaLocation` and re-encodes as `schemaLocation`, losing the prefix. It is lossy but stays well-formed, so I left it alone rather than widen this PR further.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ALA5kxeFagnWE91JBExYcV

[EN-15946]: https://bitmovin.atlassian.net/browse/EN-15946?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
